### PR TITLE
Update log level of skipped files message

### DIFF
--- a/storage/folder.go
+++ b/storage/folder.go
@@ -40,7 +40,7 @@ func DeleteObjectsWhere(folder Folder, confirm bool, filter func(object1 Object)
 			tracelog.InfoLogger.Println("\twill be deleted: " + object.GetName())
 			filteredRelativePaths = append(filteredRelativePaths, object.GetName())
 		} else {
-			tracelog.InfoLogger.Println("\tskipped: " + object.GetName())
+			tracelog.DebugLogger.Println("\tskipped: " + object.GetName())
 		}
 	}
 	if len(filteredRelativePaths) == 0 {


### PR DESCRIPTION
Hello.

I suggest changing log level of "skipped" files because in production use we don't want to know about skipped files.

We will delete, and we need to know what will be deleted. Not what will be skipped.